### PR TITLE
rename terraform-provider-equinix-metal repo name to terraform-provider-metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BREAKING CHANGES:
 
-- [#1](https://github.com/equinix/terraform-provider-equinix-metal/issues/1)
+- [#1](https://github.com/equinix/terraform-provider-metal/issues/1)
   Users migrating from the Packet provider, please follow the instructions at
   the linked issue. In short, all v3.2.0 Packet provider resources have been
   renamed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,21 +4,21 @@ Thx for your interest! We're so glad you're here.
 
 ## Important Resources
 
-- bugs: [https://github.com/equinix/terraform-provider-equinix-metal/issues](https://github.com/equinix/terraform-provider-equinix-metal/issues)
-- features: [https://github.com/equinix/terraform-provider-equinix-metal/issues](https://github.com/equinix/terraform-provider-equinix-metal/issues)
+- bugs: [https://github.com/equinix/terraform-provider-metal/issues](https://github.com/equinix/terraform-provider-metal/issues)
+- features: [https://github.com/equinix/terraform-provider-metal/issues](https://github.com/equinix/terraform-provider-metal/issues)
 
 ## Code of Conduct
 
-Available via [https://github.com/equinix/terraform-provider-equinix-metal/blob/main/.github/CODE_OF_CONDUCT.md](https://github.com/equinix/terraform-provider-equinix-metal/blob/main/.github/CODE_OF_CONDUCT.md)
+Available via [https://github.com/equinix/terraform-provider-metal/blob/main/.github/CODE_OF_CONDUCT.md](https://github.com/equinix/terraform-provider-metal/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ## Environment Details
 
-[https://github.com/equinix/terraform-provider-equinix-metal/blob/main/GNUmakefile](https://github.com/equinix/terraform-provider-equinix-metal/blob/main/GNUmakefile)
+[https://github.com/equinix/terraform-provider-metal/blob/main/GNUmakefile](https://github.com/equinix/terraform-provider-metal/blob/main/GNUmakefile)
 
 ## How to Submit Change Requests
 
-Please submit change requests and / or features via [Issues](https://github.com/equinix/terraform-provider-equinix-metal/issues). There's no guarantee it'll be changed, but you never know until you try. We'll try to add comments as soon as possible, though.
+Please submit change requests and / or features via [Issues](https://github.com/equinix/terraform-provider-metal/issues). There's no guarantee it'll be changed, but you never know until you try. We'll try to add comments as soon as possible, though.
 
 ## How to Report a Bug
 
-Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues/(https://github.com/equinix/terraform-provider-equinix-metal/issues) as well.
+Bugs are problems in code, in the functionality of an application or in its UI design; you can submit them through [Issues/(https://github.com/equinix/terraform-provider-metal/issues) as well.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Equinix Metal Terraform Provider
 
-[![GitHub release](https://img.shields.io/github/release/equinix/terraform-provider-equinix-metal/all.svg?style=flat-square)](https://github.com/equinix/terraform-provider-equinix-metal/releases)
+[![GitHub release](https://img.shields.io/github/release/equinix/terraform-provider-metal/all.svg?style=flat-square)](https://github.com/equinix/terraform-provider-metal/releases)
 ![](https://img.shields.io/badge/Stability-Maintained-green.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/equinix/terraform-provider-equinix-metal)](https://goreportcard.com/report/github.com/equinix/terraform-provider-equinix-metal)
+[![Go Report Card](https://goreportcard.com/badge/github.com/equinix/terraform-provider-metal)](https://goreportcard.com/report/github.com/equinix/terraform-provider-metal)
 
 [![Slack](https://slack.equinixmetal.com/badge.svg)](https://slack.equinixmetal.com)
 [![Twitter Follow](https://img.shields.io/twitter/follow/equinixmetal.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=equinixmetal)
@@ -19,7 +19,7 @@ See <https://registry.terraform.io/providers/equinix/equinix-metal/latest/docs> 
 
 ### Migrating from Packet
 
-[Packet is now Equinix Metal!](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/) See [Issue #1](https://github.com/equinix/terraform-provider-equinix-metal/issues/1) for more details on migrating existing projects.
+[Packet is now Equinix Metal!](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/) See [Issue #1](https://github.com/equinix/terraform-provider-metal/issues/1) for more details on migrating existing projects.
 ## Requirements
 
 - [Terraform 0.12+](https://www.terraform.io/downloads.html) (for v1.0.0 of this provider and newer)
@@ -30,8 +30,8 @@ See <https://registry.terraform.io/providers/equinix/equinix-metal/latest/docs> 
 Clone the repository, enter the provider directory, and build the provider.
 
 ```sh
-git clone git@github.com:equinix/terraform-provider-equinix-metal
-cd terraform-provider-equinix-metal
+git clone git@github.com:equinix/terraform-provider-metal
+cd terraform-provider-metal
 make build
 ```
 
@@ -44,7 +44,7 @@ To compile the provider, run `make build`. This will build the provider and put 
 ```sh
 $ make bin
 ...
-$ $GOPATH/bin/terraform-provider-equinix-metal
+$ $GOPATH/bin/terraform-provider-metal
 ...
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,15 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
+terraform {
+  required_providers {
+    metal = {
+      source = "equinix/metal"
+      # version = "1.0.0"
+    }
+  }
+}
+
 # Configure the Equinix Metal Provider.
 provider "metal" {
   auth_token = var.auth_token

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/equinix/terraform-provider-equinix-metal
+module github.com/equinix/terraform-provider-metal
 
 require (
 	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 // indirect

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/equinix/terraform-provider-equinix-metal/metal"
+	"github.com/equinix/terraform-provider-metal/metal"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 )
 

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-equinix-metal\/issues"
+PROVIDER_URL="https:\/\/github.com\/equinix\/terraform-provider-metal\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
Hyphenated provider names are represented in the Terraform registry in a
less desirable format:

```
terraform {
  required_providers {
    equinix-metal = {
      source = "equinix/equinix-metal"
      version = "1.0.0"
    }
  }
}
provider "equinix-metal" {
  # Configuration options
}
```

The resources are thus documented as `equinix-metal_device`.

The repo will be renamed to simplify consumption and avoid documentation
and publishing feature gaps related to hyphenated names.

The v1.0.0 tag will be reset since the repo will have a new name, this should not cause alarm.

Signed-off-by: Marques Johansson <mjohansson@equinix.com>